### PR TITLE
Fix missing register page route

### DIFF
--- a/app.py
+++ b/app.py
@@ -2312,6 +2312,11 @@ def formulario_evaluacion():
 @app.route('/login')
 def login_page():
     return render_template('login.html')
+
+# Route for registration page
+@app.route('/register')
+def register_page():
+    return render_template('register.html')
 # En app.py, añade esta nueva ruta:
 
 @app.route('/api/preparations', methods=['POST'])


### PR DESCRIPTION
## Summary
- add a new Flask route for `/register`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686051175c448327adfb38f72514bf43