### PR TITLE
Fix duplicate mail settings

### DIFF
--- a/config.py
+++ b/config.py
@@ -22,13 +22,6 @@ class Config:
     MAIL_USERNAME = os.environ.get('MAIL_USERNAME')
     MAIL_PASSWORD = os.environ.get('MAIL_PASSWORD')
     MAIL_DEFAULT_SENDER = os.environ.get('MAIL_DEFAULT_SENDER') or os.environ.get('MAIL_USERNAME')
-    MAIL_SERVER = os.environ.get('MAIL_SERVER')
-    MAIL_PORT = int(os.environ.get('MAIL_PORT') or 587)
-    MAIL_USE_TLS = os.environ.get('MAIL_USE_TLS', 'True').lower() in ['true', 'on', '1']
-    MAIL_USE_SSL = os.environ.get('MAIL_USE_SSL', 'False').lower() in ['true', 'on', '1']
-    MAIL_USERNAME = os.environ.get('MAIL_USERNAME')
-    MAIL_PASSWORD = os.environ.get('MAIL_PASSWORD')
-    MAIL_DEFAULT_SENDER = os.environ.get('MAIL_DEFAULT_SENDER') or os.environ.get('MAIL_USERNAME')
 
     # Firebase Configuration (placeholders, set in .env or environment)
     FIREBASE_API_KEY = os.environ.get('FIREBASE_API_KEY')


### PR DESCRIPTION
## Summary
- remove duplicate mail configuration in `Config`

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_686060c42cbc8327b716bde91127bc24