### PR TITLE
Improve patient plan formatting

### DIFF
--- a/templates/patient_plan.html
+++ b/templates/patient_plan.html
@@ -25,7 +25,9 @@
             <h4>Plan Semanal</h4>
             <div class="card">
                 <div class="card-body">
-                    <pre style="white-space: pre-wrap; word-wrap: break-word;">{{ plan_structure_text if plan_structure_text else 'Plan no disponible.' }}</pre>
+                    <div class="plan-html">
+                        {{ plan_structure_text | markdown_to_html | safe if plan_structure_text else 'Plan no disponible.' }}
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- add Markdown rendering filter with fallback logic
- strip placeholder recipe text from generated plans
- render patient plan using new Markdown formatting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68607e6d665c8327a7c745d5284aad34