### PR TITLE
Fix Markup import for Flask 3

### DIFF
--- a/app.py
+++ b/app.py
@@ -82,7 +82,7 @@ def manejar_excepcion(e):
 def load_user(user_id):
     return User.query.get(int(user_id))
 
-from flask import Markup
+from markupsafe import Markup
 try:
     import markdown as markdown_lib
 


### PR DESCRIPTION
## Summary
- update Markup import to work with Flask 3

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6860852072988327883c7025a41f1956