### PR TITLE
Add chat button to patient dashboard

### DIFF
--- a/app.py
+++ b/app.py
@@ -3059,6 +3059,7 @@ def get_my_latest_plan():
         return jsonify({'message': 'Aún no tienes un plan de alimentación disponible.'}), 404
 
     return jsonify({
+        'patient_id': patient.id,
         'patient_name': f"{patient.name} {patient.surname}",
         'consultation_date': latest_evaluation.consultation_date.strftime('%d/%m/%Y'),
         'plan_text': latest_evaluation.edited_plan_text,

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1154,7 +1154,24 @@ async function loadPatientDashboard() {
         const data = await response.json();
         if (!response.ok) throw new Error(data.message || `Error del servidor: ${response.status}`);
 
-        dashboardContainer.innerHTML = `<div class="card shadow-sm"><div class="card-header bg-primary text-white"><h3 class="mb-0">Mi Plan Nutricional</h3></div><div class="card-body"><h5 class="card-title">Hola, ${data.patient_name}</h5><p class="card-text text-muted">Este es tu plan correspondiente a la consulta del ${data.consultation_date}.</p><hr><div class="plan-text-container">${data.plan_text}</div><hr><h6 class="mt-4">Observaciones del Nutricionista:</h6><p class="text-muted fst-italic">${data.nutritionist_observations}</p></div></div>`;
+        dashboardContainer.innerHTML =
+            `<div class="card shadow-sm">
+                <div class="card-header bg-primary text-white">
+                    <h3 class="mb-0">Mi Plan Nutricional</h3>
+                </div>
+                <div class="card-body">
+                    <h5 class="card-title">Hola, ${data.patient_name}</h5>
+                    <p class="card-text text-muted">Este es tu plan correspondiente a la consulta del ${data.consultation_date}.</p>
+                    <hr>
+                    <div class="plan-text-container">${data.plan_text}</div>
+                    <hr>
+                    <h6 class="mt-4">Observaciones del Nutricionista:</h6>
+                    <p class="text-muted fst-italic">${data.nutritionist_observations}</p>
+                    <a href="/patient_chat/${data.patient_id}" class="btn btn-success mt-3">
+                        <i class="fas fa-comments"></i> Ir al Chat
+                    </a>
+                </div>
+            </div>`;
     } catch (error) {
         console.error("Error loading patient dashboard:", error);
         dashboardContainer.innerHTML = `<div class="alert alert-danger">Error al cargar tu plan: ${error.message}</div>`;


### PR DESCRIPTION
## Summary
- return patient id in latest plan API
- show a new chat button on the patient dashboard

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68616f900b188327af63446687b13d3a