### PR TITLE
Fix chat button visibility

### DIFF
--- a/templates/historial_paciente.html
+++ b/templates/historial_paciente.html
@@ -82,10 +82,10 @@
                 <button type="button" class="btn btn-info btn-sm mt-2" data-bs-toggle="modal" data-bs-target="#graficosModal">
                     <i class="fas fa-chart-area"></i> Ver Gráficos de Evolución
                 </button>
+                {% endif %}
                 <a href="{{ url_for('nutricionista_chat_view', patient_id=patient.id) }}" class="btn btn-success btn-sm mt-2">
                     <i class="fas fa-comments"></i> Chatear con Paciente
                 </a>
-                {% endif %}
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- show nutritionist chat button regardless of available chart data

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6861722d1f6483279a285eccb961cdf2