### PR TITLE
Improve responsive layout for patient pages

### DIFF
--- a/templates/patient_chat.html
+++ b/templates/patient_chat.html
@@ -19,7 +19,9 @@
     </div>
 
     <hr class="my-4">
-    <a href="{{ url_for('patient_dashboard_page') }}" class="btn btn-secondary">Volver al Dashboard</a>
+    <div class="d-grid">
+        <a href="{{ url_for('patient_dashboard_page') }}" class="btn btn-secondary w-100 w-sm-auto">Volver al Dashboard</a>
+    </div>
 
 </div>
 

--- a/templates/patient_dashboard.html
+++ b/templates/patient_dashboard.html
@@ -35,17 +35,23 @@
 {% block content %}
 <div class="container mt-5">
     <!-- Cabecera del Portal del Paciente -->
-    <div class="d-flex justify-content-between align-items-center mb-4">
-        <h2 class="mb-0">Mi Portal</h2>
-        <!-- Contenedor del botón de chat, se hará visible con JS -->
-        <div id="show-chat-button-container" style="display: none;">
-            <a href="{{ url_for('patient_shopping_list_page') }}" class="btn btn-success"><i class="fas fa-shopping-cart"></i> Lista de Compras</a>
-            <button id="show-chat-button" class="btn btn-primary ms-2" data-bs-toggle="modal" data-bs-target="#patientChatModal">
-                <i class="fas fa-comments"></i> Chatear con mi Nutricionista
-            </button>
-            <button id="open-weight-modal" class="btn btn-secondary ms-2" data-bs-toggle="modal" data-bs-target="#weightEntryModal">
-                <i class="fas fa-weight"></i> Registrar Peso
-            </button>
+    <div class="row align-items-center mb-4">
+        <div class="col-12 col-sm-auto">
+            <h2 class="mb-2 mb-sm-0">Mi Portal</h2>
+        </div>
+        <div class="col-12 col-sm">
+            <!-- Contenedor del botón de chat, se hará visible con JS -->
+            <div id="show-chat-button-container" class="d-grid gap-2 d-sm-flex justify-content-sm-end" style="display: none;">
+                <a href="{{ url_for('patient_shopping_list_page') }}" class="btn btn-success w-100 w-sm-auto">
+                    <i class="fas fa-shopping-cart"></i> Lista de Compras
+                </a>
+                <button id="show-chat-button" class="btn btn-primary w-100 w-sm-auto ms-sm-2" data-bs-toggle="modal" data-bs-target="#patientChatModal">
+                    <i class="fas fa-comments"></i> Chatear con mi Nutricionista
+                </button>
+                <button id="open-weight-modal" class="btn btn-secondary w-100 w-sm-auto ms-sm-2" data-bs-toggle="modal" data-bs-target="#weightEntryModal">
+                    <i class="fas fa-weight"></i> Registrar Peso
+                </button>
+            </div>
         </div>
     </div>
     <hr class="mb-4">

--- a/templates/patient_plan.html
+++ b/templates/patient_plan.html
@@ -50,6 +50,8 @@
     </div>
 
     <hr class="my-4">
-    <a href="{{ url_for('patient_dashboard_page') }}" class="btn btn-secondary">Volver al Dashboard</a>
+    <div class="d-grid">
+        <a href="{{ url_for('patient_dashboard_page') }}" class="btn btn-secondary w-100 w-sm-auto">Volver al Dashboard</a>
+    </div>
 </div>
 {% endblock %}

--- a/templates/patient_recipe_view.html
+++ b/templates/patient_recipe_view.html
@@ -49,8 +49,10 @@
     {% endif %}
 
     <hr class="my-4">
-    <a href="{{ url_for('patient_plan', patient_id=patient.id, evaluation_id=evaluation.id) }}" class="btn btn-secondary">Volver al Plan</a>
-    <a href="{{ url_for('patient_dashboard_page') }}" class="btn btn-secondary">Volver al Dashboard</a>
+    <div class="d-grid gap-2 d-sm-flex">
+        <a href="{{ url_for('patient_plan', patient_id=patient.id, evaluation_id=evaluation.id) }}" class="btn btn-secondary w-100 w-sm-auto">Volver al Plan</a>
+        <a href="{{ url_for('patient_dashboard_page') }}" class="btn btn-secondary w-100 w-sm-auto ms-sm-2">Volver al Dashboard</a>
+    </div>
 
 </div>
 {% endblock %}

--- a/templates/patient_shopping_list.html
+++ b/templates/patient_shopping_list.html
@@ -16,10 +16,12 @@
                 <p class="mt-2 text-muted">Cargando tu lista de compras...</p>
             </div>
         </div>
-        <div class="card-footer text-center">
-            <a href="{{ url_for('patient_dashboard_page') }}" class="btn btn-outline-secondary btn-sm">
-                <i class="fas fa-arrow-left"></i> Volver al Dashboard
-            </a>
+        <div class="card-footer">
+            <div class="d-grid">
+                <a href="{{ url_for('patient_dashboard_page') }}" class="btn btn-outline-secondary btn-sm w-100 w-sm-auto">
+                    <i class="fas fa-arrow-left"></i> Volver al Dashboard
+                </a>
+            </div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- make header button container responsive on patient dashboard
- stack navigation buttons vertically on small screens across patient pages

## Testing
- `pytest -q`
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6861fd048e80832790a86e7f9c5174a4